### PR TITLE
chore: update mento-core package to latest commit hash

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "lib/mento-core"]
 	path = lib/mento-core
 	url = https://github.com/mento-protocol/mento-core
-	branch = 93e989e16f23636748ad49e9b41161021686e88a
+	branch = 8b837b715adbca86ec73c98bf4228e025778b290
 [submodule "lib/celo-foundry"]
 	path = lib/celo-foundry
 	url = https://github.com/bowd/celo-foundry


### PR DESCRIPTION
### Description

Update mento-core submodule to point to the latest commit hash including slither and audit changes

### Other changes

n/a

### Tested

n/a

### Related issues

- Fixes #3 

### Backwards compatibility

n/a

### Documentation

n/a
