### PR TITLE
feat: add some core contracts to type generation

### DIFF
--- a/generateTypes.js
+++ b/generateTypes.js
@@ -2,15 +2,20 @@ const { runTypeChain, glob } = require("typechain");
 const fs = require("fs");
 
 async function main() {
-  let cwd = process.cwd();
-  const interfacesPath = cwd + "/lib/mento-core/contracts/interfaces";
+  const cwd = process.cwd()
+  const interfaces = fs.readdirSync(
+    `${cwd}/lib/mento-core/contracts/interfaces`
+  );
+  // We generate types for some of the core contracts because they are
+  // useful in other packages, for example in the sdk.
+  const coreContracts = ['Broker.sol', 'BiPoolManager.sol']
+  const allContracts = interfaces.concat(coreContracts)
+  const allContractsPath = allContracts.map(
+    (contract) => `${contract}/${contract.replace('.sol', '.json')}`
+  )
 
-  let files = await fs.readdirSync(interfacesPath);
-  files = files.map(file => {
-    return file + "/" + file.replace("sol", "json");
-  });
-  const allFiles = glob(cwd + "/out", files);
-  const result = runTypeChain({
+  const allFiles = glob(`${cwd}/out`, allContractsPath);
+  await runTypeChain({
     cwd,
     filesToProcess: allFiles,
     allFiles,
@@ -18,4 +23,5 @@ async function main() {
     target: "ethers-v5",
   });
 }
+
 main().catch(console.error);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@mento-protocol/mento-core-ts",
   "description": "Mento type generation and npm package dployment repo",
   "license": "GPL-3.0-or-later",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "files": [
     "dist",
     "contracts",


### PR DESCRIPTION
### Description

This adds *some* core contracts to the type generation so that we can use them in other projects. The reason why we need this is because the interfaces don't have view methods for all the data needed for the circuit breaker/trading limits integration in the SDK.

### Other changes

Did some small refactor to the `generateTypes.js` script

### Tested

Ran it locally and verified that types were generated for all the interfaces + the hardcoded contracts
```
λ › yarn generatetypes
yarn run v1.17.3
$ node generateTypes.js
✨  Done in 1.89s.
λ › ls src/
BiPoolManager.ts  IBiPoolManager.ts  IBrokerAdmin.ts       index.ts           IStableToken.ts
Broker.ts         IBreaker.ts        ICeloToken.ts         IPricingModule.ts
common.ts         IBreakerBox.ts     IExchange.ts          IReserve.ts
factories         IBroker.ts         IExchangeProvider.ts  ISortedOracles.ts
```

### Related issues

-

### Backwards compatibility

Yes, since were adding extra types and not removing any of the existing ones 

### Documentation

-
