### PR TITLE
feat: update gen types to include new contracts

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "lib/celo-foundry"]
 	path = lib/celo-foundry
 	url = https://github.com/bowd/celo-foundry
-[submodule "lib/mento-core"]
-	path = lib/mento-core
-	url = https://github.com/mento-protocol/mento-core

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "lib/celo-foundry"]
 	path = lib/celo-foundry
 	url = https://github.com/bowd/celo-foundry
+[submodule "lib/mento-core"]
+	path = lib/mento-core
+	url = https://github.com/mento-protocol/mento-core

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
-[submodule "lib/mento-core"]
-	path = lib/mento-core
-	url = https://github.com/mento-protocol/mento-core
-	branch = 8b837b715adbca86ec73c98bf4228e025778b290
 [submodule "lib/celo-foundry"]
 	path = lib/celo-foundry
 	url = https://github.com/bowd/celo-foundry

--- a/foundry.toml
+++ b/foundry.toml
@@ -3,8 +3,6 @@ src = "lib/mento-core/contracts"
 out = "out"
 test = "test"
 libs = ["lib"]
-auto_detect_solc = false
-solc = "0.5.17"
+auto_detect_solc = true
 legacy = true
-
-
+via_ir = true

--- a/generateTypes.js
+++ b/generateTypes.js
@@ -2,17 +2,20 @@ const { runTypeChain, glob } = require("typechain");
 const fs = require("fs");
 
 async function main() {
-  const cwd = process.cwd()
-  const interfaces = fs.readdirSync(
-    `${cwd}/lib/mento-core/contracts/interfaces`
-  );
-  // We generate types for some of the core contracts because they are
-  // useful in other packages, for example in the sdk.
-  const coreContracts = ['Broker.sol', 'BiPoolManager.sol']
-  const allContracts = interfaces.concat(coreContracts)
-  const allContractsPath = allContracts.map(
-    (contract) => `${contract}/${contract.replace('.sol', '.json')}`
-  )
+  const cwd = process.cwd();
+  const interfaces = fs.readdirSync(`${cwd}/lib/mento-core/contracts/interfaces`);
+
+  const governanceContracts = fs.readdirSync(`${cwd}/lib/mento-core/contracts/governance`);
+  const oracleContracts = fs.readdirSync(`${cwd}/lib/mento-core/contracts/oracles`);
+  const breakerContracts = fs.readdirSync(`${cwd}/lib/mento-core/contracts/oracles/breakers`);
+  const swapContracts = fs.readdirSync(`${cwd}/lib/mento-core/contracts/swap`);
+
+  const allContracts = interfaces
+    .concat(governanceContracts)
+    .concat(oracleContracts)
+    .concat(breakerContracts)
+    .concat(swapContracts);
+  const allContractsPath = allContracts.map(contract => `${contract}/${contract.replace(".sol", ".json")}`);
 
   const allFiles = glob(`${cwd}/out`, allContractsPath);
   await runTypeChain({


### PR DESCRIPTION
### Description

- This PR updates the generate types script to include the new contracts that have been added in the recent Mento upgrades

### Other changes

- None

### Tested

- Ran script locally to verify new contract types were included as well as the existing types

### Related issues

- https://github.com/mento-protocol/mento-sdk/issues/30

### Backwards compatibility

Yes

### Documentation

- N/A
