### PR TITLE
Fix install fail (husky)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@mento-protocol/mento-core-ts",
   "description": "Mento type generation and npm package deployment repo",
   "license": "GPL-3.0-or-later",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "files": [
     "dist",
     "contracts",
@@ -44,9 +44,7 @@
   "scripts": {
     "lint": "yarn prettier",
     "lint:check": "yarn prettier:check",
-    "postinstall": "husky install",
-    "prepack": "pinst --disable",
-    "postpack": "pinst --enable",
+    "prepare": "husky install",
     "prettier": "prettier --config \"./.prettierrc.yml\" --write \"**/*.{json,md,js,yml}\"",
     "prettier:check": "prettier --config \"./.prettierrc.yml\" --check \"**/*.{json,md,js,yml}\"",
     "generatetypes": "node generateTypes.js",


### PR DESCRIPTION

### Description

[as reported by yours truly](https://github.com/mento-protocol/mento-core-ts/issues/13) mento-core-ts fails to install when A) the installer is using npm AND B) does not have husky installed globally) 

the package uses a postinstall script which although prefixed by an underscore seems to still be called. regardless [husky recommends to run  itself inside of `prepare` ](https://blog.typicode.com/posts/husky-git-hooks-autoinstall/)

[dont use postinstall](https://yarnpkg.com/advanced/lifecycle-scripts#postinstall)


### Other changes
i removed the pinst calls as i think they were just for transforming `postinstall` into `_postinstall`

### Tested


[packed  mento-protocol-mento-core-ts-v0.2.3.tgz](https://github.com/user-attachments/files/16579744/mento-protocol-mento-core-ts-v0.2.3.tgz) and ran


### Related issues

- fix https://github.com/mento-protocol/mento-core-ts/issues/13
- https://github.com/mento-protocol/mento-sdk/issues/60

### Backwards compatibility

just an install script change

### Documentation

n.a