### PR TITLE
Feat/update interfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ yarn-error.log*
 # build files
 src/
 dist/
+abis/

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@
 .tool-versions
 yarn-debug.log*
 yarn-error.log*
+
+# build files
+src/
+dist/

--- a/foundry.lock
+++ b/foundry.lock
@@ -1,0 +1,11 @@
+{
+  "lib/celo-foundry": {
+    "rev": "aba8615646acc8c3f3cc83cf13eab1795600c388"
+  },
+  "lib/mento-core": {
+    "tag": {
+      "name": "v2.6.5",
+      "rev": "4ce201f85b3230b1db0afa45296f3b3d6ce9e2d2"
+    }
+  }
+}

--- a/foundry.toml
+++ b/foundry.toml
@@ -5,4 +5,3 @@ test = "test"
 libs = ["lib"]
 auto_detect_solc = true
 legacy = true
-via_ir = true

--- a/generateTypes.js
+++ b/generateTypes.js
@@ -19,7 +19,10 @@ async function main() {
     .concat(swapContracts);
   const allContractsPath = allContracts.map(contract => `${contract}/${contract.replace(".sol", ".json")}`);
 
-  const allFiles = glob(`${cwd}/out`, allContractsPath);
+  /// XXX: there's an IBreakerBox in the @celo/contracts package as well so we need a manual shady intervention.
+  fs.cpSync(`${cwd}/out/IBreakerBox.sol/IBreakerBox.0.5.17.json`, `${cwd}/out/IBreakerBox.sol/IBreakerBox.json`);
+
+  const allFiles = glob(`${cwd}/out`, allContractsPath)
   await runTypeChain({
     cwd,
     filesToProcess: allFiles,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@mento-protocol/mento-core-ts",
   "description": "Mento type generation and npm package deployment repo",
   "license": "GPL-3.0-or-later",
-  "version": "2.6.5-rc2",
+  "version": "2.6.5-rc3",
   "files": [
     "dist",
     "contracts",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@mento-protocol/mento-core-ts",
   "description": "Mento type generation and npm package deployment repo",
   "license": "GPL-3.0-or-later",
-  "version": "2.6.5-rc1",
+  "version": "2.6.5-rc2",
   "files": [
     "dist",
     "contracts",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@mento-protocol/mento-core-ts",
   "description": "Mento type generation and npm package deployment repo",
   "license": "GPL-3.0-or-later",
-  "version": "2.6.5-rc0",
+  "version": "2.6.5-rc1",
   "files": [
     "dist",
     "contracts",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@mento-protocol/mento-core-ts",
   "description": "Mento type generation and npm package deployment repo",
   "license": "GPL-3.0-or-later",
-  "version": "0.2.3",
+  "version": "2.6.5-rc0",
   "files": [
     "dist",
     "contracts",


### PR DESCRIPTION
### Description

The latest version was missing some functions that were added to the interfaces. I tried simply regenerating them, but because of changes in `mento-core`, the build script didn't work anymore, and it needed some massaging. I updated the ABI lookup to use `forge inspect <contract name>` because the out files had solidity versions appended to the filename, and that introduced issues. 

### Other changes

Change the versioning to mirror mento-core. Currently, the v2.6.5-rc3 release is based on this branch. 

### Tested

Yes

### Related issues

N/A

### Backwards compatibility

Yes

### Documentation

N/A
